### PR TITLE
Adding rinari-web-server-restart

### DIFF
--- a/rinari.el
+++ b/rinari.el
@@ -305,13 +305,10 @@ argument allows editing of the server command arguments."
   "If rinari-web-server is running, kill it and start a new server, otherwise just launch the server"
   (interactive "P")
   (let ((rinari-web-server-buffer "*server*"))
-  (if (get-buffer rinari-web-server-buffer)
-      (progn
-        (set-process-query-on-exit-flag (get-buffer-process rinari-web-server-buffer) nil)
-        (kill-buffer rinari-web-server-buffer))
-    nil)
+    (when (get-buffer rinari-web-server-buffer)
+      (set-process-query-on-exit-flag (get-buffer-process rinari-web-server-buffer) nil)
+      (kill-buffer rinari-web-server-buffer))
     (rinari-web-server edit-cmd-args)))
-
 
 (defun rinari-insert-erb-skeleton (no-equals)
   "Insert an erb skeleton at point, with optional prefix argument


### PR DESCRIPTION
Hello,

I've added a function to ease restarting the server within rinari.  rinari-web-server-restart will check for an existing server instance and kill it if it exists, followed by launching rinari-web-server.

Thanks.
