### PR TITLE
Rspec 2.0 fix

### DIFF
--- a/util/ruby-compilation-rspec.el
+++ b/util/ruby-compilation-rspec.el
@@ -12,7 +12,7 @@
                             (when (and (not (null buffer-file-name)) (string-match "_spec.rb$" buffer-file-name))
                               (set (make-local-variable 'ruby-compilation-executable)
                                    (if (some (lambda (x)
-                                               (file-executable-p (concat x "/rspec")))
+                                               (file-executable-p (expand-file-name "rspec" x)))
                                              exec-path)
                                        "rspec"
                                    "spec"))


### PR DESCRIPTION
The rspec maintainers, in their infinite wisdom, renamed the utility from spec to rspec. I think this change should allow us to handle both versions.

If you know of a better way to detect if rspec is in path, feel free to replace what I've done in here. Also, you can merge the two changes into one. They are not in my master yet, so I can happily merge back your commit.
