### PR TITLE
Added support for spork server and rspec.

### DIFF
--- a/util/ruby-compilation-rspec.el
+++ b/util/ruby-compilation-rspec.el
@@ -29,4 +29,24 @@
   "Return the line number at point"
   (number-to-string (line-number-at-pos)))
 
+(defmacro with-spork-if-rspec (&rest body)
+  `(let ((ruby-compilation-executable-args ruby-compilation-executable-args))
+     (with-spork-if
+         (string-equal ruby-compilation-executable "rspec")
+         (setf ruby-compilation-executable-args
+               (cons "--drb"
+                     ruby-compilation-executable-args))
+       ,@body)))
+
+(defun ruby-compilation-rspec-use-spork ()
+  (interactive)
+  (defadvice ruby-compilation-this-buffer (around
+                                           ruby-compilation-this-buffer-spork
+                                           activate)
+    (with-spork-if-rspec ad-do-it))
+  (defadvice ruby-compilation-this-test (around
+                                         ruby-compilation-this-test-spork
+                                         activate)
+    (with-spork-if-rspec ad-do-it)))
+
 (provide 'ruby-compilation-rspec)

--- a/util/ruby-compilation.el
+++ b/util/ruby-compilation.el
@@ -71,6 +71,11 @@
 (defvar ruby-compilation-executable "ruby"
   "What bin to use to launch the tests. Override if you use JRuby etc.")
 
+(defvar ruby-compilation-executable-args nil
+  "A list of command line arguments passed to
+ruby-compilation-executable in functions ruby-compilation-run and
+ruby-compilation-this-test")
+
 (defvar ruby-compilation-executable-rake "rake"
   "What bin to use to launch rake. Override if you use JRuby etc.")
 
@@ -115,6 +120,7 @@ name to construct the name of the compilation buffer."
   (interactive "FRuby Comand: ")
   (let ((name (or name (file-name-nondirectory (car (split-string cmd)))))
 	(cmdlist (append (list ruby-compilation-executable)
+                         ruby-compilation-executable-args
                          ruby-options
                          (split-string (expand-file-name cmd)))))
     (pop-to-buffer (ruby-compilation-do name cmdlist))))
@@ -190,9 +196,10 @@ name to construct the name of the compilation buffer."
   (let ((test-name (ruby-compilation-this-test-name)))
     (pop-to-buffer (ruby-compilation-do
                     (ruby-compilation-this-test-buffer-name test-name)
-                    (list ruby-compilation-executable
-                          (buffer-file-name)
-                          ruby-compilation-test-name-flag test-name)))))
+                    (append (list ruby-compilation-executable)
+                            ruby-compilation-executable-args
+                            (list (buffer-file-name)
+                                  ruby-compilation-test-name-flag test-name))))))
 
 (defun ruby-compilation-this-test-buffer-name (test-name)
   "The name of the buffer in which test-at-point will run."

--- a/util/spork-server.el
+++ b/util/spork-server.el
@@ -1,0 +1,118 @@
+;; Add spork support to ruby-compilation-rspec
+
+;;
+;; This module provides interactive functions to start, kill and restart the spork server.
+;; In addition, it can hook necessary functions to allow rspec to use spork.
+;;
+
+(defvar spork-server-autostart t
+  "Set this variable to nil if you don't want spork to be executed automatically")
+
+(defconst spork-server-buffer-name "spork-server"
+  "The name of the buffer that runs spork server.
+This is the name without the enclosing *s")
+
+(defconst spork-server-buffer-real-name (concat "*" spork-server-buffer-name "*")
+  "The visible name of the buffer that runs spork server")
+
+(defun have-spork-p ()
+  (executable-find "spork"))
+
+(defun spork-inactive-p ()
+  (let* ((spork-buffer (get-buffer spork-server-buffer-real-name))
+         (spork-process (and spork-buffer
+                             (get-buffer-process spork-buffer))))
+    (null spork-process)))
+
+(defun wait-spork-start-or-kill ()
+  "Wait for the spork server to become active.
+This function also detects if spork needs to be bootstrapped. If the spork
+server is started successfully, it reports the port spork listens to."
+  (let* ((spork-buffer (get-buffer spork-server-buffer-real-name))
+         (proc (get-buffer-process spork-buffer))
+         (old-filter (process-filter proc))
+         (old-sentinel (process-sentinel proc))
+         (output "") spork-terminated spork-port)
+    (set-process-filter proc (lambda (proc string)
+                               (setf output (concat output string))
+                                ;; Chain to the old filter
+                               (if old-filter
+                                   (funcall old-filter proc string))))
+    (set-process-sentinel proc (lambda (proc state)
+                                 (unless (eq 'run
+                                             (process-status proc))
+                                   (setf spork-terminated t))))
+    (save-match-data
+      (while (cond
+              ;; Make sure this project can handle spork
+              ((string-match "has not been bootstrapped" output)
+               (kill-spork)
+               (message "Failed to start spork server. Did you run \"spork --bootstrap\"?")
+               nil)                        ; stop loop
+              ;; Wait for the server to start - and report its port. I am putting this after the
+              ;; bootstrap check, because the message can also appear even when project is not
+              ;; bootstrapped for spork.
+              ((string-match "listening on \\([0-9]+\\)" output)
+               (setq spork-port (match-string 1 output))
+               (message (concat "Spork serving at port " spork-port))
+               nil)                        ; stop loop
+              ;; See if process died
+              (spork-terminated
+               ;; Put appropriate message if we know why
+               (if (string-match "spork is not part of the bundle" output)
+                   (message "Failed to start spork server. Did you add spork to project Gemfile?")
+                 (message "Spork server died unexpectedly."))
+               nil)                        ; stop loop
+              ;; If we need to loop, wait for more output
+              (t (accept-process-output proc)
+                 t))))                 ;continue looping
+    (set-process-sentinel proc old-sentinel)
+    (set-process-filter proc old-filter)
+    spork-port))
+
+(defun start-spork ()
+  "Start a spork server, and return the port it is listening as a string.
+If the projet is not configured to run spork, the server is killed and nil is returned."
+  (interactive)
+  (when (and (spork-inactive-p)
+             (have-spork-p))
+    (message "Starting spork server...")
+    (ruby-compilation-do spork-server-buffer-name
+                         (list "bundle" "exec" "spork"))
+    (wait-spork-start-or-kill)))
+
+(defun kill-spork (&optional buffer-name)
+  "If a spork server is running, this function kills both the process and the buffer."
+  (interactive)
+  (let* ((spork-buffer (get-buffer spork-server-buffer-real-name))
+         (proc (get-buffer-process spork-buffer)))
+    (when proc
+      (delete-process proc))
+    (when spork-buffer
+      (kill-buffer spork-buffer))))
+
+(defun restart-spork ()
+  "Restart a running spork server.
+If the server is not running, this function only starts the spork server."
+  (interactive)
+  (if (not (spork-inactive-p))
+      (kill-spork))
+  (start-spork))
+
+(defmacro with-spork-if (condition action &rest body)
+  "A macro to simplify spork server integration.
+CONDITION is evaluated to see if spork is required. If it is not nil, presence
+of spork server is checked. If it is present, ACTION is executed before BODY.
+
+If spork-server-autostart is not nil, then the macro
+attempts to start spork-server automatically."
+  (declare (indent 2))
+  `(when ,condition
+     (if (and (spork-inactive-p)
+              spork-server-autostart)
+         (start-spork))
+     (if (not (spork-inactive-p))
+         ,action)
+     ,@body))
+
+(provide 'spork-server)


### PR DESCRIPTION
- Added new file to manage the spork server.
- Modified a few functions in ruby-compilation.el to allow passing extra
  arguments to the executable.
- Added a new function to ruby-compilation-rspec.el to use the spork server when
  possible.

I am not very confident about the way I have done some of the things - especially the macros. Also, I didn't add (require 'spork-server) to ruby-compilation-rspec intentionally to keep the dependencies down. With these changes, you enable spork in your config file as:

```
(require 'ruby-compilation-rspec)
(require 'spork-server)
(ruby-compilation-rspec-use-spork)
```
