### PR TITLE
small bug-fix to split string properly in `run-ruby'

### DIFF
--- a/util/inf-ruby.el
+++ b/util/inf-ruby.el
@@ -200,7 +200,7 @@ of `ruby-program-name').  Runs the hooks `inferior-ruby-mode-hook'
   (setq name (or name "ruby"))
 
   (if (not (comint-check-proc inf-ruby-buffer))
-      (let ((commandlist (split-string command)))
+      (let ((commandlist (split-string-and-unquote command)))
         (set-buffer (apply 'make-comint name (car commandlist)
                            nil (cdr commandlist)))
         (inf-ruby-mode)))


### PR DESCRIPTION
I use cygwin tools, and cygwin Ruby 1.9 in a native build windows of Emacs.  So I have use a string that contains a quoted string in to eventually call run-ruby like this:

  (run-ruby "sh -c \"irb --inf-ruby-mode -r irb/completion\"" "ruby")

this patch calls split-string-and-unquote to parse the string properly.  It should not break anything else where.  I can't imagine a context where it's better to always split on space.
