### PR TITLE
normalize whitespace in rinari.el and rinari-merb.el

### DIFF
--- a/rinari-merb.el
+++ b/rinari-merb.el
@@ -55,9 +55,9 @@
 ;;; Code:
 (let* ((this-dir (file-name-directory (or load-file-name buffer-file-name)))
        (util-dir (file-name-as-directory
-		  (expand-file-name "util" this-dir)))
+                  (expand-file-name "util" this-dir)))
        (jump-dir (file-name-as-directory
-		  (expand-file-name "jump" util-dir))))
+                  (expand-file-name "jump" util-dir))))
   (add-to-list 'load-path this-dir)
   (add-to-list 'load-path util-dir)
   (add-to-list 'load-path jump-dir))
@@ -91,22 +91,22 @@
 
 (defun rinari-merb-parse-yaml ()
   (let ((start (point))
-	(end (save-excursion (re-search-forward "^$" nil t) (point)))
-	alist)
+        (end (save-excursion (re-search-forward "^$" nil t) (point)))
+        alist)
     (while (and (< (point) end)
-		(re-search-forward "^ *:?\\(.*\\): \\(.*\\)$" nil t))
+                (re-search-forward "^ *:?\\(.*\\): \\(.*\\)$" nil t))
       (setf alist (cons (cons (match-string 1) (match-string 2)) alist)))
     alist))
 
 (defun rinari-merb-root (&optional dir home)
   (or dir (setq dir default-directory))
   (if (file-exists-p (expand-file-name
-		      "init.rb"
-		      (file-name-as-directory (expand-file-name "config" dir))))
+                      "init.rb"
+                      (file-name-as-directory (expand-file-name "config" dir))))
       dir
     (let ((new-dir (expand-file-name (file-name-as-directory "..") dir)))
       (unless (string-match "\\(^[[:alpha:]]:/$\\|^/$\\)" dir)
-	(rinari-merb-root new-dir)))))
+        (rinari-merb-root new-dir)))))
 
 ;;--------------------------------------------------------------------------------
 ;; user functions
@@ -124,13 +124,13 @@ editing of the rake command arguments."
 directory of the rails application."
   (interactive)
   (let* ((root (rinari-merb-root))
-	 (script (or script
-		     (completing-read "Script: " (directory-files (concat root "script") nil "^[^.]"))))
-	 (ruby-compilation-error-regexp-alist ;; for jumping to newly created files
-	  (if (equal script "generate")
-	      '(("^ +\\(exists\\|create\\) +\\([^[:space:]]+\\.rb\\)" 2 3))
-	    ruby-compilation-error-regexp-alist))
-	 (script (concat "script/" script " ")))
+         (script (or script
+                     (completing-read "Script: " (directory-files (concat root "script") nil "^[^.]"))))
+         (ruby-compilation-error-regexp-alist ;; for jumping to newly created files
+          (if (equal script "generate")
+              '(("^ +\\(exists\\|create\\) +\\([^[:space:]]+\\.rb\\)" 2 3))
+            ruby-compilation-error-regexp-alist))
+         (script (concat "script/" script " ")))
     (ruby-compilation-run (concat root script (read-from-minibuffer script)))))
 
 (defun rinari-merb-test (&optional edit-cmd-args)
@@ -141,19 +141,19 @@ jumping between errors and source code.  With optional prefix
 argument allows editing of the test command arguments."
   (interactive "P")
   (or (string-match "spec" (or (ruby-add-log-current-method)
-			       (file-name-nondirectory (buffer-file-name))))
+                               (file-name-nondirectory (buffer-file-name))))
       (rinari-merb-find-rspec))
   (let* ((funname (ruby-add-log-current-method))
-	 (fn (and funname
-		  (string-match "#\\(.*\\)" funname)
-		  (match-string 1 funname)))
-	 (path (buffer-file-name))
-	 (default-command (if fn
-			      (concat path " --name /" fn "/")
-			    path))
-	 (command (if edit-cmd-args
-		      (read-string "Run w/Compilation: " default-command)
-		    default-command)))
+         (fn (and funname
+                  (string-match "#\\(.*\\)" funname)
+                  (match-string 1 funname)))
+         (path (buffer-file-name))
+         (default-command (if fn
+                              (concat path " --name /" fn "/")
+                            path))
+         (command (if edit-cmd-args
+                      (read-string "Run w/Compilation: " default-command)
+                    default-command)))
     (if path (ruby-compilation-run command)
       (message "no test available"))))
 
@@ -170,31 +170,31 @@ from your conf/database.sql file."
   (interactive)
   (flet ((sql-name (env) (format "*%s-sql*" env)))
     (let* ((environment (or (getenv "RAILS_ENV") "development"))
-	   (sql-buffer (get-buffer (sql-name environment))))
+           (sql-buffer (get-buffer (sql-name environment))))
       (if sql-buffer
-	  (pop-to-buffer sql-buffer)
-	(let* ((database-alist (save-excursion
-				 (with-temp-buffer
-				   (insert-file-contents
-				    (expand-file-name
-				     "database.yml"
-				     (file-name-as-directory
-				      (expand-file-name "config" (rinari-merb-root)))))
-				   (goto-char (point-min))
-				   (re-search-forward (concat "^:?" environment ":"))
-				   (rinari-merb-parse-yaml))))
-	       (adapter (or (cdr (assoc "adapter" database-alist)) "sqlite"))
-	       (sql-user (or (cdr (assoc "username" database-alist)) "root"))
-	       (sql-password (or (cdr (assoc "password" database-alist)) ""))
-	       (sql-database (or (cdr (assoc "database" database-alist))
-				 (concat (file-name-nondirectory (rinari-merb-root))
-					 "_" environment)))
-	       (server (or (cdr (assoc "host" database-alist)) "localhost"))
-	       (port (cdr (assoc "port" database-alist)))
-	       (sql-server (if port (concat server ":" port) server)))
-	  (if (string-match "sqlite" adapter) (setf adapter "sqlite"))
-	  (eval (list (intern (concat "sql-" adapter))))
-	  (rename-buffer (sql-name environment)) (rinari-merb-launch))))))
+          (pop-to-buffer sql-buffer)
+        (let* ((database-alist (save-excursion
+                                 (with-temp-buffer
+                                   (insert-file-contents
+                                    (expand-file-name
+                                     "database.yml"
+                                     (file-name-as-directory
+                                      (expand-file-name "config" (rinari-merb-root)))))
+                                   (goto-char (point-min))
+                                   (re-search-forward (concat "^:?" environment ":"))
+                                   (rinari-merb-parse-yaml))))
+               (adapter (or (cdr (assoc "adapter" database-alist)) "sqlite"))
+               (sql-user (or (cdr (assoc "username" database-alist)) "root"))
+               (sql-password (or (cdr (assoc "password" database-alist)) ""))
+               (sql-database (or (cdr (assoc "database" database-alist))
+                                 (concat (file-name-nondirectory (rinari-merb-root))
+                                         "_" environment)))
+               (server (or (cdr (assoc "host" database-alist)) "localhost"))
+               (port (cdr (assoc "port" database-alist)))
+               (sql-server (if port (concat server ":" port) server)))
+          (if (string-match "sqlite" adapter) (setf adapter "sqlite"))
+          (eval (list (intern (concat "sql-" adapter))))
+          (rename-buffer (sql-name environment)) (rinari-merb-launch))))))
 
 (defun rinari-merb-merb (&optional name args edit-cmd-args)
   "Run merb.  Dump output to a compilation buffer
@@ -202,14 +202,14 @@ allowing jumping between errors and source code.  With optional
 prefix argument allows editing of the server command arguments."
   (interactive "P")
   (let* ((default-directory (rinari-merb-root))
-	 (name (if name name "server"))
-	 (args (if args args ""))
-	 (args (if edit-cmd-args
-		   (read-from-minibuffer "Edit Merb Command: " args)
-		 args)))
+         (name (if name name "server"))
+         (args (if args args ""))
+         (args (if edit-cmd-args
+                   (read-from-minibuffer "Edit Merb Command: " args)
+                 args)))
     (pop-to-buffer (ruby-compilation-do
-		    name (cons "merb"
-				   (ruby-args-to-list args))))
+                    name (cons "merb"
+                                   (ruby-args-to-list args))))
     (rinari-merb-launch)))
 
 (defun rinari-merb-insert-erb-skeleton (no-equals)
@@ -223,18 +223,18 @@ don't include an '='."
   (interactive "r\nsName your partial: ")
   (let* ((path (buffer-file-name)) ending)
     (if (string-match "view" path)
-	(let ((ending (and (string-match ".+?\\(\\..*\\)" path)
-			   (match-string 1 path)))
-	      (partial-name
-	       (replace-regexp-in-string "[[:space:]]+" "_" partial-name)))
-	  (kill-region begin end)
-	  (if (string-match "\\(.+\\)/\\(.+\\)" partial-name)
-	      (let ((default-directory (expand-file-name (match-string 1 partial-name)
-							 (expand-file-name ".."))))
-		(find-file (concat "_" (match-string 2 partial-name) ending)))
-	    (find-file (concat "_" partial-name ending)))
-	  (yank) (pop-to-buffer nil)
-	  (insert (concat "<%= render :partial => '" partial-name "' %>\n")))
+        (let ((ending (and (string-match ".+?\\(\\..*\\)" path)
+                           (match-string 1 path)))
+              (partial-name
+               (replace-regexp-in-string "[[:space:]]+" "_" partial-name)))
+          (kill-region begin end)
+          (if (string-match "\\(.+\\)/\\(.+\\)" partial-name)
+              (let ((default-directory (expand-file-name (match-string 1 partial-name)
+                                                         (expand-file-name ".."))))
+                (find-file (concat "_" (match-string 2 partial-name) ending)))
+            (find-file (concat "_" partial-name ending)))
+          (yank) (pop-to-buffer nil)
+          (insert (concat "<%= render :partial => '" partial-name "' %>\n")))
       (message "not in a view"))))
 
 (defvar rinari-merb-rgrep-file-endings
@@ -249,15 +249,15 @@ With optional prefix argument just run `rgrep'."
   (if arg (call-interactively 'rgrep)
     (let ((word (thing-at-point 'word)))
       (funcall 'rgrep (read-from-minibuffer "search for: " word)
-	       rinari-merb-rgrep-file-endings (rinari-merb-root)))))
+               rinari-merb-rgrep-file-endings (rinari-merb-root)))))
 
 ;;--------------------------------------------------------------------
 ;; rinari-merb movement using jump.el
 
 (defun rinari-merb-generate (type name)
   (message (shell-command-to-string
-	    (format "ruby %sscript/generate %s %s" (rinari-merb-root) type
-		    (read-from-minibuffer (format "create %s: " type) name)))))
+            (format "ruby %sscript/generate %s %s" (rinari-merb-root) type
+                    (read-from-minibuffer (format "create %s: " type) name)))))
 
 (defvar rinari-merb-ruby-hash-regexp
   "\\(:[^[:space:]]*?\\)[[:space:]]*\\(=>[[:space:]]*[\"\':]?\\([^[:space:]]*?\\)[\"\']?[[:space:]]*\\)?[,){}\n]"
@@ -267,24 +267,24 @@ With optional prefix argument just run `rgrep'."
   "Adjusts CONTROLLER and ACTION acording to keyword arguments in
 the hash at `point', then return (CONTROLLER . ACTION)"
   (let ((end (save-excursion
-	       (re-search-forward "[^,{(]$" nil t)
-	       (+ 1 (point)))))
+               (re-search-forward "[^,{(]$" nil t)
+               (+ 1 (point)))))
     (save-excursion
       (while (and (< (point) end)
-		  (re-search-forward rinari-merb-ruby-hash-regexp end t))
-	(if (> (length (match-string 3)) 1)
-	    (case (intern (match-string 1))
-	      (:partial (setf action (concat "_" (match-string 3))))
-	      (:action  (setf action (match-string 3)))
-	      (:controller (setf controller (match-string 3)))))))
+                  (re-search-forward rinari-merb-ruby-hash-regexp end t))
+        (if (> (length (match-string 3)) 1)
+            (case (intern (match-string 1))
+              (:partial (setf action (concat "_" (match-string 3))))
+              (:action  (setf action (match-string 3)))
+              (:controller (setf controller (match-string 3)))))))
     (cons controller action)))
 
 (defun rinari-merb-which-render (renders)
   (let ((path (jump-completing-read
-	       "Follow: "
-	       (mapcar (lambda (lis)
-			 (concat (car lis) "/" (cdr lis)))
-		       renders))))
+               "Follow: "
+               (mapcar (lambda (lis)
+                         (concat (car lis) "/" (cdr lis)))
+                       renders))))
     (string-match "\\(.*\\)/\\(.*\\)" path)
     (cons (match-string 1 path) (match-string 2 path))))
 
@@ -293,23 +293,23 @@ the hash at `point', then return (CONTROLLER . ACTION)"
 renders and redirects to find the final controller or view."
   (save-excursion ;; if we can find the controller#action pair
     (if (and (jump-to-path (format "app/controllers/%s_controller.rb#%s" controller action))
-	     (equalp (jump-method) action))
-	(let ((start (point)) ;; demarcate the borders
-	      (renders (list (cons controller action))) render view)
-	  (ruby-forward-sexp)
-	  ;; collect redirection options and pursue
-	  (while (re-search-backward "re\\(?:direct_to\\|nder\\)" start t)
-	    (add-to-list 'renders (rinari-merb-ruby-values-from-render controller action)))
-	  (let ((render (if (equalp 1 (length renders))
-			    (car renders)
-			  (rinari-merb-which-render renders))))
-	    (if (and (equalp (cdr render) action)
-		     (equalp (car render) controller))
-		(list controller action) ;; directed to here so return
-	      (rinari-merb-follow-controller-and-action (or (car render)
-						       controller)
-						   (or (cdr render)
-						       action)))))
+             (equalp (jump-method) action))
+        (let ((start (point)) ;; demarcate the borders
+              (renders (list (cons controller action))) render view)
+          (ruby-forward-sexp)
+          ;; collect redirection options and pursue
+          (while (re-search-backward "re\\(?:direct_to\\|nder\\)" start t)
+            (add-to-list 'renders (rinari-merb-ruby-values-from-render controller action)))
+          (let ((render (if (equalp 1 (length renders))
+                            (car renders)
+                          (rinari-merb-which-render renders))))
+            (if (and (equalp (cdr render) action)
+                     (equalp (car render) controller))
+                (list controller action) ;; directed to here so return
+              (rinari-merb-follow-controller-and-action (or (car render)
+                                                       controller)
+                                                   (or (cdr render)
+                                                       action)))))
       ;; no controller entry so return
       (list controller action))))
 
@@ -332,8 +332,8 @@ renders and redirects to find the final controller or view."
      (t                                        . "app/models/"))
     (lambda (path)
       (rinari-merb-generate "model"
-		       (and (string-match ".*/\\(.+?\\)\.rb" path)
-			    (match-string 1 path)))))
+                       (and (string-match ".*/\\(.+?\\)\.rb" path)
+                            (match-string 1 path)))))
    (controller
     "c"
     (("app/models/\\1.rb"                      . "app/controllers/\\1.rb")
@@ -352,22 +352,22 @@ renders and redirects to find the final controller or view."
      (t                                        . "app/controllers/"))
     (lambda (path)
       (rinari-merb-generate "controller"
-		       (and (string-match ".*/\\(.+?\\)_controller\.rb" path)
-			    (match-string 1 path)))))
+                       (and (string-match ".*/\\(.+?\\)_controller\.rb" path)
+                            (match-string 1 path)))))
    (view
     "v"
     (("app/models/\\1.rb"                      . "app/views/\\1/.*")
      ((lambda () ;; find the controller/view
-	(let* ((raw-file (and (buffer-file-name)
-			      (file-name-nondirectory (buffer-file-name))))
-	       (file (and raw-file
-			  (string-match "^\\(.*\\)_controller.rb" raw-file)
-			  (match-string 1 raw-file))) ;; controller
-	       (raw-method (ruby-add-log-current-method))
-	       (method (and file raw-method ;; action
-			    (string-match "#\\(.*\\)" raw-method)
-			    (match-string 1 raw-method))))
-	  (if (and file method) (rinari-merb-follow-controller-and-action file method))))
+        (let* ((raw-file (and (buffer-file-name)
+                              (file-name-nondirectory (buffer-file-name))))
+               (file (and raw-file
+                          (string-match "^\\(.*\\)_controller.rb" raw-file)
+                          (match-string 1 raw-file))) ;; controller
+               (raw-method (ruby-add-log-current-method))
+               (method (and file raw-method ;; action
+                            (string-match "#\\(.*\\)" raw-method)
+                            (match-string 1 raw-method))))
+          (if (and file method) (rinari-merb-follow-controller-and-action file method))))
       . "app/views/\\1/\\2.*")
      ("app/helpers/\\1_helper.rb"              . "app/views/\\1/.*")
      ("schema/migrations/.*_\\1_migration.rb"  . "app/views/\\1/.*")
@@ -459,8 +459,8 @@ renders and redirects to find the final controller or view."
      (t                                        . "schema/migrations/"))
     (lambda (path)
       (rinari-merb-generate "migration"
-		       (and (string-match ".*create_\\(.+?\\)\.rb" path)
-			    (match-string 1 path)))))
+                       (and (string-match ".*create_\\(.+?\\)\.rb" path)
+                            (match-string 1 path)))))
    (environment "e" ((t . "config/environments/")) nil)
    (configuration "n" ((t . "config/")) nil)
    (script "s" ((t . "script/")) nil)
@@ -476,15 +476,15 @@ renders and redirects to find the final controller or view."
 (mapcar
  (lambda (type)
    (let ((name (first type))
-	 (specs (third type))
-	 (make (fourth type)))
+         (specs (third type))
+         (make (fourth type)))
      (eval `(defjump
-	      (quote ,(read (format "rinari-merb-find-%S" name)))
-	      (quote ,specs)
-	      'rinari-merb-root
-	      ,(format "Go to the most logical %S given the current location" name)
-	      ,(if make `(quote ,make))
-	      'ruby-add-log-current-method))))
+              (quote ,(read (format "rinari-merb-find-%S" name)))
+              (quote ,specs)
+              'rinari-merb-root
+              ,(format "Go to the most logical %S given the current location" name)
+              ,(if make `(quote ,make))
+              'ruby-add-log-current-method))))
  rinari-merb-jump-schema)
 
 ;;--------------------------------------------------------------------
@@ -496,10 +496,10 @@ renders and redirects to find the final controller or view."
   "Key map for Rinari-Merb minor mode.")
 
 (defun rinari-merb-bind-key-to-func (key func)
-  (eval `(define-key rinari-merb-minor-mode-map 
-	   ,(format "\C-c;%s" key) ,func))
-  (eval `(define-key rinari-merb-minor-mode-map 
-	   ,(format "\C-c'%s" key) ,func)))
+  (eval `(define-key rinari-merb-minor-mode-map
+           ,(format "\C-c;%s" key) ,func))
+  (eval `(define-key rinari-merb-minor-mode-map
+           ,(format "\C-c'%s" key) ,func)))
 
 (defvar rinari-merb-minor-mode-keybindings
   '(("s" . 'rinari-merb-script)              ("q" . 'rinari-merb-sql)
@@ -510,11 +510,11 @@ renders and redirects to find the final controller or view."
   "alist mapping of keys to functions in `rinari-merb-minor-mode'")
 
 (mapcar (lambda (el) (rinari-merb-bind-key-to-func (car el) (cdr el)))
-	(append (mapcar (lambda (el)
-			  (cons (concat "f" (second el))
-				(read (format "'rinari-merb-find-%S" (first el)))))
-			rinari-merb-jump-schema)
-		rinari-merb-minor-mode-keybindings))
+        (append (mapcar (lambda (el)
+                          (cons (concat "f" (second el))
+                                (read (format "'rinari-merb-find-%S" (first el)))))
+                        rinari-merb-jump-schema)
+                rinari-merb-minor-mode-keybindings))
 
 (defun rinari-merb-launch ()
   "Run `rinari-merb-minor-mode' if inside of a rails projecct,
@@ -522,10 +522,10 @@ otherwise turn `rinari-merb-minor-mode' off if it is on."
   (interactive)
   (let* ((root (rinari-merb-root)) (r-tags-path (concat root rinari-merb-tags-file-name)))
     (if root (progn
-	       (set (make-local-variable 'tags-file-name)
-		    (and (file-exists-p r-tags-path) r-tags-path))
-	       (run-hooks 'rinari-merb-minor-mode-hook)
-	       (rinari-merb-minor-mode t))
+               (set (make-local-variable 'tags-file-name)
+                    (and (file-exists-p r-tags-path) r-tags-path))
+               (run-hooks 'rinari-merb-minor-mode-hook)
+               (rinari-merb-minor-mode t))
       (if rinari-merb-minor-mode (rinari-merb-minor-mode)))))
 
 (defvar rinari-merb-major-modes
@@ -533,9 +533,9 @@ otherwise turn `rinari-merb-minor-mode' off if it is on."
   "Major Modes from which to launch Rinari-Merb.")
 
 (mapcar (lambda (hook)
-	  (eval `(add-hook ,hook
-			   (lambda () (rinari-merb-launch)))))
-	rinari-merb-major-modes)
+          (eval `(add-hook ,hook
+                           (lambda () (rinari-merb-launch)))))
+        rinari-merb-major-modes)
 
 (defadvice cd (after rinari-merb-on-cd activate)
   "Active/Deactive rinari-merb-minor-node when changing into and out


### PR DESCRIPTION
This normalizes whitespace in rinari.el and rinari-merb.el, replacing tabs with spaces. Can go the other way as well if you guys prefer spaces, but it looked like the majority of indentation was spaces.
