### PR TITLE
Syntax highlighting

### DIFF
--- a/rinari.el
+++ b/rinari.el
@@ -201,8 +201,6 @@ Optional argument HOME is ignored."
   "Highlight the passed KEYWORDS in current buffer.
 Use `font-lock-add-keywords' in case of `ruby-mode' or
 `ruby-extra-keywords' in case of Enhanced Ruby Mode."
-  (print "called")
-  (print keywords)
   (if (boundp 'ruby-extra-keywords)
       (progn
 	(setq ruby-extra-keywords (append ruby-extra-keywords keywords))


### PR DESCRIPTION
[vim-rails](https://github.com/tpope/vim-rails) has got really nice syntax highlighting for words specific to rails like belongs_to, redirect_to and so on. Should rinari define additional keywords or it is more a case of individual setup?
