### PR TITLE
Prompt to save modified buffers before running Ruby

### DIFF
--- a/util/ruby-compilation.el
+++ b/util/ruby-compilation.el
@@ -109,6 +109,8 @@ Should be used with `make-local-variable'.")
 ;; Low-level API entry point
 (defun ruby-compilation-do (name cmdlist)
   "In a compilation buffer identified by NAME, run CMDLIST."
+  (save-some-buffers (not compilation-ask-about-save)
+                     compilation-save-buffers-predicate)
   (let* ((buffer (apply 'make-comint name (car cmdlist) nil (cdr cmdlist)))
          (proc (get-buffer-process buffer)))
     (with-current-buffer buffer


### PR DESCRIPTION
Modifies ruby-compilation-do so that it prompts to save any modified buffers before running a compilation.  It uses the same method to do this that compile.el does for other compilations.

There may be some other places that this needs to happen, such as in cucumber-mode-compilation, but I don't use Cucumber, so I'm not sure I could test the behavior in a valid way there.
