### PR TITLE
Add a basic menu

### DIFF
--- a/rinari.el
+++ b/rinari.el
@@ -77,6 +77,7 @@
 (require 'ruby-compilation)
 (require 'jump)
 (require 'cl)
+(require 'easymenu)
 
 ;; fill in some missing variables for XEmacs
 (when (eval-when-compile (featurep 'xemacs))
@@ -832,6 +833,51 @@ and redirects."
                             rinari-jump-schema)
                     rinari-minor-mode-keybindings))
   (rinari-bind-key-to-func (car el) (cdr el)))
+
+(easy-menu-define rinari-minor-mode-menu rinari-minor-mode-map
+  "Rinari menu"
+  '("Rinari"
+    ["Search" rinari-rgrep t]
+    "---"
+    ["Find file in project" rinari-find-file-in-project t]
+    ["Find file by context" rinari-find-by-context t]
+    ("Jump to..."
+     ["Model" rinari-find-model t]
+     ["Controller" rinari-find-controller t]
+     ["View" rinari-find-view t]
+     ["Helper" rinari-find-helper t]
+     ["Worker" rinari-find-worker t]
+     ["Mailer" rinari-find-mailer t]
+     "---"
+     ["Javascript" rinari-find-javascript t]
+     ["Stylesheet" rinari-find-stylesheet t]
+     ["Sass" rinari-find-sass t]
+     ["public/" rinari-find-public t]
+     "---"
+     ["Test" rinari-find-test t]
+     ["Rspec" rinari-find-rspec t]
+     ["Fixture" rinari-find-fixture t]
+     ["Rspec fixture" rinari-find-rspec-fixture t]
+     ["Feature" rinari-find-features t]
+     ["Step" rinari-find-steps t]
+     "---"
+     ["application.rb" rinari-find-application t]
+     ["config/" rinari-find-configuration t]
+     ["environments/" rinari-find-environment t]
+     ["migrate/" rinari-find-migration t]
+     ["lib/" rinari-find-lib t]
+     ["script/" rinari-find-script t]
+     ["log/" rinari-find-log t])
+    "---"
+    ("Web server"
+     ["Start" rinari-web-server t]
+     ["Restart" rinari-web-server-restart t])
+    ["Console" rinari-console t]
+    ["SQL prompt" rinari-sql t]
+    "---"
+    ["Script" rinari-script t]
+    ["Rake" rinari-rake t]
+    ["Cap" rinari-cap t]))
 
 ;;;###autoload
 (defun rinari-launch ()


### PR DESCRIPTION
Here is code to add a Rinari menu for those who use the menu bar.  I did my best to organize the menu logically but am open to suggestions.

I used easymenu which seems to be included in emacs 23 and 24.  I tested both versions on ubuntu 12.10.

I'm an elisp novice, so feel free to suggest improvements.  It seems like I could drive some of the menu creation from the rinari-jump-schema with a few additions, but I didn't want to dig into that code and muddy it's current purpose.
