### PR TITLE
autoloads for rinari-rake and rinari-cap helps using them with keybindings

### DIFF
--- a/rinari.el
+++ b/rinari.el
@@ -237,6 +237,7 @@ Use `font-lock-add-keywords' in case of `ruby-mode' or
 ;;--------------------------------------------------------------------------------
 ;; user functions
 
+;;;###autoload
 (defun rinari-rake (&optional task edit-cmd-args)
   "Select and run a rake TASK using `ruby-compilation-rake'."
   (interactive "P")
@@ -255,6 +256,7 @@ Use `font-lock-add-keywords' in case of `ruby-mode' or
                            edit-cmd-args
                            (list (cons "VERSION" n)))))
 
+;;;###autoload
 (defun rinari-cap (&optional task edit-cmd-args)
   "Select and run a capistrano TASK using `ruby-compilation-cap'."
   (interactive "P")


### PR DESCRIPTION
that's it. I have rinari-cap and rinari-rake bound for keys.

this patch enables me not to require rinari in my init file to get them working
